### PR TITLE
Remove framerate dependence

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -70,6 +70,7 @@ var target;
 
 var strokes = 0;
 var currentStrokeTime = 0;
+var lastUpdateTime = performance.now();
 var strokeTimingOn = false;
 
 var selected = 5;
@@ -132,7 +133,7 @@ function startup() {
 // update()
 //
 // Called every frame
-function update() {
+function update(currentTime) {
 
   window.requestAnimationFrame(update);
 
@@ -161,7 +162,9 @@ function update() {
   }
 
   if (strokeTimingOn) {
-    currentStrokeTime++;
+    var deltaTime = (currentTime - lastUpdateTime) / 1000; // time in seconds between frames
+    currentStrokeTime += 60 * deltaTime;  // at 60 fps, currentStrokeTime changes by 1 per frame
+    lastUpdateTime = currentTime;
   }
 }
 

--- a/js/script.js
+++ b/js/script.js
@@ -61,6 +61,7 @@ var currentStrokeInstruction = '';
 const MAX_STROKE_SPEED_ERRORS = 3;
 const SLOW_STROKE_MIN_FRAMES = 40;
 const FAST_STROKE_MAX_FRAMES = 40;
+const STROKE_FRAME_EPSILON = 1/13; // 1/13th of a 60hz frame, chosen because 13 is prime and this is just under half of a 360hz frame
 var desiredStrokeSpeeds = ["slowly","quickly"];
 var currentDesiredStrokeSpeed = "slowly";
 var strokeSpeedErrors = 0;
@@ -823,7 +824,7 @@ function handleSuccessfulSelection() {
   console.log("Stroke time: " + currentStrokeTime);
 
   // Check the stroke time
-  if (currentDesiredStrokeSpeed == "slowly" && currentStrokeTime < SLOW_STROKE_MIN_FRAMES) {
+  if (currentDesiredStrokeSpeed == "slowly" && currentStrokeTime < SLOW_STROKE_MIN_FRAMES - STROKE_FRAME_EPSILON) {
     strokeSpeedErrors++;
     setMessage(currentStrokeInstruction  + ' ' +  getRandom(negativeSlowlyFeedbacks) + pleaseOrPeriod);
     if (strokeSpeedErrors > MAX_STROKE_SPEED_ERRORS) {
@@ -832,7 +833,7 @@ function handleSuccessfulSelection() {
       strokes = 0; // Reset strokes at this point, they need to work on it!
     }
   }
-  else if (currentDesiredStrokeSpeed == "quickly" && currentStrokeTime > FAST_STROKE_MAX_FRAMES) {
+  else if (currentDesiredStrokeSpeed == "quickly" && currentStrokeTime > FAST_STROKE_MAX_FRAMES + STROKE_FRAME_EPSILON) {
     strokeSpeedErrors++;
     setMessage(currentStrokeInstruction  + ' ' +  getRandom(negativeQuicklyFeedbacks) + pleaseOrPeriod);
     if (strokeSpeedErrors > MAX_STROKE_SPEED_ERRORS) {


### PR DESCRIPTION
Currently, the stroke time counter updates once per frame. Since fast strokes can't be slower than 40 frames, and the slider must be at the target value for 250 ms to count, playing at >60 fps ranges from frustrating to impossible. (My experience at 144Hz required moving the slider from A to B in 28 ms!)

This solves that by multiplying the stroke time counter by a computed deltatime. An epsilon is added to prevent the newly possible floating point imprecision from making the number of frames per stroke inconsistent. 

I spent  ̵a̵n̵ ̵u̵n̵r̵e̵a̵s̵o̵n̵a̵b̵l̵e̵  a scientific amount of time determining what epsilon should be, and settled on 1/13 of a 60Hz frame, just under half of a 360Hz frame. I'm sure the 500Hz users will find some way to forgive me for the 2ms inconsistencies.

Tracking down the repository and making a pull request seems like a measured response to my computer telling me I'm bad at sliding, right?